### PR TITLE
Update zeddy's maplist url

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -10,7 +10,7 @@
 		},
 		{
 			"name": "Zeddy Zombie Escape",
-			"mapList": "https://raw.githubusercontent.com/notkoen/zeddy-server-public-configs/main/maplist.csv",
+			"mapList": "https://raw.githubusercontent.com/notkoen/Zombie-Escape-Configs/main/misc/zeddy/maplist.csv",
 			"fastDL": "http://sgfastdl.streamline-servers.com/fastdl/Zeddy/maps/",
 			"appID": "730",
 			"mapsDirectory": "\\csgo\\maps\\"


### PR DESCRIPTION
Due to some internal restructuring, several GitHub repositories were renamed and files were moved around.